### PR TITLE
Document that the platform configuration and callbacks can be discarded after initialization

### DIFF
--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -185,6 +185,7 @@ static const uint8_t NMBS_BROADCAST_ADDRESS = 0;
 
 #ifndef NMBS_CLIENT_DISABLED
 /** Create a new Modbus client.
+ * The platform configuration struct is copied by value and may be discarded afterwards.
  * @param nmbs pointer to the nmbs_t instance where the client will be created.
  * @param platform_conf nmbs_platform_conf struct with platform configuration.
  *
@@ -195,6 +196,7 @@ nmbs_error nmbs_client_create(nmbs_t* nmbs, const nmbs_platform_conf* platform_c
 
 #ifndef NMBS_SERVER_DISABLED
 /** Create a new Modbus server.
+ * The platform configuration and callback structs are copied by value and may be discarded afterwards.
  * @param nmbs pointer to the nmbs_t instance where the client will be created.
  * @param address_rtu RTU address of this server. Can be 0 if transport is not RTU.
  * @param platform_conf nmbs_platform_conf struct with platform configuration.

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -185,9 +185,8 @@ static const uint8_t NMBS_BROADCAST_ADDRESS = 0;
 
 #ifndef NMBS_CLIENT_DISABLED
 /** Create a new Modbus client.
- * The platform configuration struct is copied by value and may be discarded afterwards.
  * @param nmbs pointer to the nmbs_t instance where the client will be created.
- * @param platform_conf nmbs_platform_conf struct with platform configuration.
+ * @param platform_conf nmbs_platform_conf struct with platform configuration. It may be discarded after calling this method.
  *
 * @return NMBS_ERROR_NONE if successful, NMBS_ERROR_INVALID_ARGUMENT otherwise.
  */
@@ -196,11 +195,10 @@ nmbs_error nmbs_client_create(nmbs_t* nmbs, const nmbs_platform_conf* platform_c
 
 #ifndef NMBS_SERVER_DISABLED
 /** Create a new Modbus server.
- * The platform configuration and callback structs are copied by value and may be discarded afterwards.
  * @param nmbs pointer to the nmbs_t instance where the client will be created.
  * @param address_rtu RTU address of this server. Can be 0 if transport is not RTU.
- * @param platform_conf nmbs_platform_conf struct with platform configuration.
- * @param callbacks nmbs_callbacks struct with server request callbacks.
+ * @param platform_conf nmbs_platform_conf struct with platform configuration. It may be discarded after calling this method.
+ * @param callbacks nmbs_callbacks struct with server request callbacks. It may be discarded after calling this method.
  *
  * @return NMBS_ERROR_NONE if successful, NMBS_ERROR_INVALID_ARGUMENT otherwise.
  */


### PR DESCRIPTION
`nmbs_client_create` accepts a `const nmbs_platform_conf* platform_conf` with configuration. Without reading the source code, it is not clear whether or not the object pointed to by `platform_conf` can be declared on the stack, or if it needs to be kept alive for the duration of the program (as would be the case if the implementation simply kept a pointer to the configuration instead of copying it by value). This PR adds an assurance that it is OK to discard the platform configuration after calling `nmbs_client_create`. Same idea for `nmbs_server_create`.