### PR TITLE
Make the debug output less likely to clash with output from the callbacks

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -228,6 +228,8 @@ static nmbs_error send(nmbs_t* nmbs, uint16_t count) {
 
 
 static nmbs_error recv_msg_footer(nmbs_t* nmbs) {
+    DEBUG("\n");
+
     if (nmbs->platform.transport == NMBS_TRANSPORT_RTU) {
         uint16_t crc = crc_calc(nmbs->msg.buf, nmbs->msg.buf_idx);
 
@@ -241,7 +243,6 @@ static nmbs_error recv_msg_footer(nmbs_t* nmbs) {
             return NMBS_ERROR_CRC;
     }
 
-    DEBUG("\n");
 
     return NMBS_ERROR_NONE;
 }
@@ -396,6 +397,8 @@ static void send_msg_header(nmbs_t* nmbs, uint16_t data_length) {
 
 
 static nmbs_error send_msg_footer(nmbs_t* nmbs) {
+    DEBUG("\n");
+
     if (nmbs->platform.transport == NMBS_TRANSPORT_RTU) {
         uint16_t crc = crc_calc(nmbs->msg.buf, nmbs->msg.buf_idx);
         put_2(nmbs, crc);
@@ -403,7 +406,6 @@ static nmbs_error send_msg_footer(nmbs_t* nmbs) {
 
     nmbs_error err = send(nmbs, nmbs->msg.buf_idx);
 
-    DEBUG("\n");
 
     return err;
 }


### PR DESCRIPTION
Sometimes it's useful to turn `NMBS_DEBUG` on, but the output is a bit of a mess if the read/write callbacks also log to the same channel. Moving the DEBUG statements in `recv_msg_footer` and `send_msg_footer` to the start of those functions makes the output a bit cleaner, although it's not perfect.

Example output before this change:

```
NMBS req -> fc 16   a 12326 q 2     b 4     regs 4660 43981 transmitted[13] = { f7, 10, 30, 26, 00, 02, 04, 12, 34, ab, cd, c2, 04, }

received[1] = { f7, }
received[1] = { 10, }
NMBS res <- fc 16   received[4] = { 30, 26, 00, 02, }
a 12326     q 2received[2] = { bb, 95, }

NMBS req -> fc 3    a 12326 q 2 transmitted[8] = { f7, 03, 30, 26, 00, 02, 3e, 56, }

received[1] = { f7, }
received[1] = { 03, }
NMBS res <- fc 3    received[1] = { 04, }
b 4 received[4] = { 12, 34, ab, cd, }
regs 466043981received[2] = { 96, 2f, }
```

after:

```
NMBS req -> fc 16   a 12326 q 2     b 4     regs 4660 43981
transmitted[13] = { f7, 10, 30, 26, 00, 02, 04, 12, 34, ab, cd, c2, 04, }
received[1] = { f7, }
received[1] = { 10, }
NMBS res <- fc 16   received[4] = { 30, 26, 00, 02, }
a 12326     q 2
received[2] = { bb, 95, }
NMBS req -> fc 3    a 12326 q 2
transmitted[8] = { f7, 03, 30, 26, 00, 02, 3e, 56, }
received[1] = { f7, }
received[1] = { 03, }
NMBS res <- fc 3    received[1] = { 04, }
b 4 received[4] = { 12, 34, ab, cd, }
regs 466043981
received[2] = { 96, 2f, }
```