### PR TITLE
Send platform argument to nmbs_callbacks

### DIFF
--- a/examples/arduino/server-rtu/server-rtu.ino
+++ b/examples/arduino/server-rtu/server-rtu.ino
@@ -42,7 +42,7 @@ void onError() {
 }
 
 
-nmbs_error handle_read_coils(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out) {
+nmbs_error handle_read_coils(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out, void *arg) {
   if (address + quantity > COILS_ADDR_MAX + 1)
     return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 
@@ -56,7 +56,7 @@ nmbs_error handle_read_coils(uint16_t address, uint16_t quantity, nmbs_bitfield 
 }
 
 
-nmbs_error handle_write_multiple_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils) {
+nmbs_error handle_write_multiple_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils, void *arg) {
   if (address + quantity > COILS_ADDR_MAX + 1)
     return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 
@@ -69,7 +69,7 @@ nmbs_error handle_write_multiple_coils(uint16_t address, uint16_t quantity, cons
 }
 
 
-nmbs_error handler_read_holding_registers(uint16_t address, uint16_t quantity, uint16_t* registers_out) {
+nmbs_error handler_read_holding_registers(uint16_t address, uint16_t quantity, uint16_t* registers_out, void *arg) {
   if (address + quantity > REGS_ADDR_MAX + 1)
     return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 
@@ -81,7 +81,7 @@ nmbs_error handler_read_holding_registers(uint16_t address, uint16_t quantity, u
 }
 
 
-nmbs_error handle_write_multiple_registers(uint16_t address, uint16_t quantity, const uint16_t* registers) {
+nmbs_error handle_write_multiple_registers(uint16_t address, uint16_t quantity, const uint16_t* registers, void *arg) {
   if (address + quantity > REGS_ADDR_MAX + 1)
     return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 

--- a/examples/linux/server-tcp.c
+++ b/examples/linux/server-tcp.c
@@ -27,7 +27,9 @@
 nmbs_bitfield server_coils = {0};
 uint16_t server_registers[REGS_ADDR_MAX] = {0};
 
-nmbs_error handle_read_coils(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out) {
+nmbs_error handle_read_coils(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address + quantity > COILS_ADDR_MAX + 1)
         return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 
@@ -41,7 +43,9 @@ nmbs_error handle_read_coils(uint16_t address, uint16_t quantity, nmbs_bitfield 
 }
 
 
-nmbs_error handle_write_multiple_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils) {
+nmbs_error handle_write_multiple_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address + quantity > COILS_ADDR_MAX + 1)
         return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 
@@ -54,7 +58,9 @@ nmbs_error handle_write_multiple_coils(uint16_t address, uint16_t quantity, cons
 }
 
 
-nmbs_error handler_read_holding_registers(uint16_t address, uint16_t quantity, uint16_t* registers_out) {
+nmbs_error handler_read_holding_registers(uint16_t address, uint16_t quantity, uint16_t* registers_out, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address + quantity > REGS_ADDR_MAX + 1)
         return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 
@@ -66,7 +72,9 @@ nmbs_error handler_read_holding_registers(uint16_t address, uint16_t quantity, u
 }
 
 
-nmbs_error handle_write_multiple_registers(uint16_t address, uint16_t quantity, const uint16_t* registers) {
+nmbs_error handle_write_multiple_registers(uint16_t address, uint16_t quantity, const uint16_t* registers, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address + quantity > REGS_ADDR_MAX + 1)
         return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
 

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -443,7 +443,7 @@ static nmbs_error send_exception_msg(nmbs_t* nmbs, uint8_t exception) {
 
 
 #ifndef NMBS_SERVER_DISABLED
-static nmbs_error handle_read_discrete(nmbs_t* nmbs, nmbs_error (*callback)(uint16_t, uint16_t, nmbs_bitfield)) {
+static nmbs_error handle_read_discrete(nmbs_t* nmbs, nmbs_error (*callback)(uint16_t, uint16_t, nmbs_bitfield, void*)) {
     nmbs_error err = recv(nmbs, 4);
     if (err != NMBS_ERROR_NONE)
         return err;
@@ -466,7 +466,7 @@ static nmbs_error handle_read_discrete(nmbs_t* nmbs, nmbs_error (*callback)(uint
 
         if (callback) {
             nmbs_bitfield bf = {0};
-            err = callback(address, quantity, bf);
+            err = callback(address, quantity, bf, nmbs->platform.arg);
             if (err != NMBS_ERROR_NONE) {
                 if (nmbs_error_is_exception(err))
                     return send_exception_msg(nmbs, err);
@@ -504,7 +504,7 @@ static nmbs_error handle_read_discrete(nmbs_t* nmbs, nmbs_error (*callback)(uint
 
 
 #ifndef NMBS_SERVER_DISABLED
-static nmbs_error handle_read_registers(nmbs_t* nmbs, nmbs_error (*callback)(uint16_t, uint16_t, uint16_t*)) {
+static nmbs_error handle_read_registers(nmbs_t* nmbs, nmbs_error (*callback)(uint16_t, uint16_t, uint16_t*, void*)) {
     nmbs_error err = recv(nmbs, 4);
     if (err != NMBS_ERROR_NONE)
         return err;
@@ -527,7 +527,7 @@ static nmbs_error handle_read_registers(nmbs_t* nmbs, nmbs_error (*callback)(uin
 
         if (callback) {
             uint16_t regs[125] = {0};
-            err = callback(address, quantity, regs);
+            err = callback(address, quantity, regs, nmbs->platform.arg);
             if (err != NMBS_ERROR_NONE) {
                 if (nmbs_error_is_exception(err))
                     return send_exception_msg(nmbs, err);
@@ -612,7 +612,7 @@ static nmbs_error handle_write_single_coil(nmbs_t* nmbs) {
             if (value != 0 && value != 0xFF00)
                 return send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
-            err = nmbs->callbacks.write_single_coil(address, value == 0 ? false : true);
+            err = nmbs->callbacks.write_single_coil(address, value == 0 ? false : true, nmbs->platform.arg);
             if (err != NMBS_ERROR_NONE) {
                 if (nmbs_error_is_exception(err))
                     return send_exception_msg(nmbs, err);
@@ -659,7 +659,7 @@ static nmbs_error handle_write_single_register(nmbs_t* nmbs) {
 
     if (!nmbs->msg.ignored) {
         if (nmbs->callbacks.write_single_register) {
-            err = nmbs->callbacks.write_single_register(address, value);
+            err = nmbs->callbacks.write_single_register(address, value, nmbs->platform.arg);
             if (err != NMBS_ERROR_NONE) {
                 if (nmbs_error_is_exception(err))
                     return send_exception_msg(nmbs, err);
@@ -729,7 +729,7 @@ static nmbs_error handle_write_multiple_coils(nmbs_t* nmbs) {
             return send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
         if (nmbs->callbacks.write_multiple_coils) {
-            err = nmbs->callbacks.write_multiple_coils(address, quantity, coils);
+            err = nmbs->callbacks.write_multiple_coils(address, quantity, coils, nmbs->platform.arg);
             if (err != NMBS_ERROR_NONE) {
                 if (nmbs_error_is_exception(err))
                     return send_exception_msg(nmbs, err);
@@ -799,7 +799,7 @@ static nmbs_error handle_write_multiple_registers(nmbs_t* nmbs) {
             return send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
         if (nmbs->callbacks.write_multiple_registers) {
-            err = nmbs->callbacks.write_multiple_registers(address, quantity, registers);
+            err = nmbs->callbacks.write_multiple_registers(address, quantity, registers, nmbs->platform.arg);
             if (err != NMBS_ERROR_NONE) {
                 if (nmbs_error_is_exception(err))
                     return send_exception_msg(nmbs, err);

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -139,16 +139,19 @@ typedef struct nmbs_platform_conf {
 
 /**
  * Modbus server request callbacks. Passed to nmbs_server_create().
+ *
+ * These methods accept a pointer to arbitrary user-data, which is the arg member of the nmbs_platform_conf that was passed
+ * to nmbs_server_create together with this struct.
  */
 typedef struct nmbs_callbacks {
-    nmbs_error (*read_coils)(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out);
-    nmbs_error (*read_discrete_inputs)(uint16_t address, uint16_t quantity, nmbs_bitfield inputs_out);
-    nmbs_error (*read_holding_registers)(uint16_t address, uint16_t quantity, uint16_t* registers_out);
-    nmbs_error (*read_input_registers)(uint16_t address, uint16_t quantity, uint16_t* registers_out);
-    nmbs_error (*write_single_coil)(uint16_t address, bool value);
-    nmbs_error (*write_single_register)(uint16_t address, uint16_t value);
-    nmbs_error (*write_multiple_coils)(uint16_t address, uint16_t quantity, const nmbs_bitfield coils);
-    nmbs_error (*write_multiple_registers)(uint16_t address, uint16_t quantity, const uint16_t* registers);
+    nmbs_error (*read_coils)(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out, void *arg);
+    nmbs_error (*read_discrete_inputs)(uint16_t address, uint16_t quantity, nmbs_bitfield inputs_out, void *arg);
+    nmbs_error (*read_holding_registers)(uint16_t address, uint16_t quantity, uint16_t* registers_out, void *arg);
+    nmbs_error (*read_input_registers)(uint16_t address, uint16_t quantity, uint16_t* registers_out, void *arg);
+    nmbs_error (*write_single_coil)(uint16_t address, bool value, void *arg);
+    nmbs_error (*write_single_register)(uint16_t address, uint16_t value, void *arg);
+    nmbs_error (*write_multiple_coils)(uint16_t address, uint16_t quantity, const nmbs_bitfield coils, void *arg);
+    nmbs_error (*write_multiple_registers)(uint16_t address, uint16_t quantity, const uint16_t* registers, void *arg);
 } nmbs_callbacks;
 
 

--- a/tests/nanomodbus_tests.c
+++ b/tests/nanomodbus_tests.c
@@ -156,7 +156,9 @@ void test_server_receive_base(nmbs_transport transport) {
 }
 
 
-nmbs_error read_discrete(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out) {
+nmbs_error read_discrete(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address == 1)
         return -1;
 
@@ -323,7 +325,9 @@ void test_fc2(nmbs_transport transport) {
 }
 
 
-nmbs_error read_registers(uint16_t address, uint16_t quantity, uint16_t* registers_out) {
+nmbs_error read_registers(uint16_t address, uint16_t quantity, uint16_t* registers_out, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address == 1)
         return -1;
 
@@ -453,7 +457,9 @@ void test_fc4(nmbs_transport transport) {
 }
 
 
-nmbs_error write_coil(uint16_t address, bool value) {
+nmbs_error write_coil(uint16_t address, bool value, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address == 1)
         return -1;
 
@@ -518,7 +524,9 @@ void test_fc5(nmbs_transport transport) {
 }
 
 
-nmbs_error write_register(uint16_t address, uint16_t value) {
+nmbs_error write_register(uint16_t address, uint16_t value, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address == 1)
         return -1;
 
@@ -576,7 +584,9 @@ void test_fc6(nmbs_transport transport) {
 }
 
 
-nmbs_error write_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils) {
+nmbs_error write_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address == 1)
         return -1;
 
@@ -690,7 +700,9 @@ void test_fc15(nmbs_transport transport) {
 }
 
 
-nmbs_error write_registers(uint16_t address, uint16_t quantity, const uint16_t* registers) {
+nmbs_error write_registers(uint16_t address, uint16_t quantity, const uint16_t* registers, void *arg) {
+    UNUSED_PARAM(arg);
+
     if (address == 1)
         return -1;
 


### PR DESCRIPTION
This is useful for the same reasons that the arg is useful in the platform callbacks (e.g. if you have multiple servers on the same device)