### PR TITLE
Fix Clang static analyser nit: zero out nmbs_bitfield structs.

### DIFF
--- a/examples/arduino/client-rtu/client-rtu.ino
+++ b/examples/arduino/client-rtu/client-rtu.ino
@@ -57,7 +57,7 @@ void loop() {
   nmbs_set_destination_rtu_address(&nmbs, RTU_SERVER_ADDRESS);
 
   // Write 2 coils from address 64
-  nmbs_bitfield coils;
+  nmbs_bitfield coils = {0};
   nmbs_bitfield_write(coils, 0, 1);
   nmbs_bitfield_write(coils, 1, 1);
   err = nmbs_write_multiple_coils(&nmbs, 64, 2, coils);

--- a/examples/linux/client-tcp.c
+++ b/examples/linux/client-tcp.c
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
     nmbs_set_read_timeout(&nmbs, 1000);
 
     // Write 2 coils from address 64
-    nmbs_bitfield coils;
+    nmbs_bitfield coils = {0};
     nmbs_bitfield_write(coils, 0, 1);
     nmbs_bitfield_write(coils, 1, 1);
     err = nmbs_write_multiple_coils(&nmbs, 64, 2, coils);

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -669,7 +669,7 @@ static nmbs_error handle_write_multiple_coils(nmbs_t* nmbs) {
     if (err != NMBS_ERROR_NONE)
         return err;
 
-    nmbs_bitfield coils;
+    nmbs_bitfield coils = {0};
     for (int i = 0; i < coils_bytes; i++) {
         coils[i] = get_1(nmbs);
         NMBS_DEBUG_PRINT("%d ", coils[i]);

--- a/tests/nanomodbus_tests.c
+++ b/tests/nanomodbus_tests.c
@@ -235,7 +235,7 @@ void test_fc1(nmbs_transport transport) {
     expect(nmbs_read_coils(&CLIENT, 3, 1, NULL) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("read with no error");
-    nmbs_bitfield bf;
+    nmbs_bitfield bf = {0};
     check(nmbs_read_coils(&CLIENT, 10, 3, bf));
     expect(nmbs_bitfield_read(bf, 0) == 1);
     expect(nmbs_bitfield_read(bf, 1) == 0);
@@ -302,7 +302,7 @@ void test_fc2(nmbs_transport transport) {
     expect(nmbs_read_discrete_inputs(&CLIENT, 3, 1, NULL) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("read with no error");
-    nmbs_bitfield bf;
+    nmbs_bitfield bf = {0};
     check(nmbs_read_discrete_inputs(&CLIENT, 10, 3, bf));
     expect(nmbs_bitfield_read(bf, 0) == 1);
     expect(nmbs_bitfield_read(bf, 1) == 0);


### PR DESCRIPTION
Do you have any thoughts on this? Better safe than sorry. 