### PR TITLE
adds fc23

### DIFF
--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -391,6 +391,25 @@ nmbs_error nmbs_read_file_record(nmbs_t* nmbs, uint16_t file_number, uint16_t re
 nmbs_error nmbs_write_file_record(nmbs_t* nmbs, uint16_t file_number, uint16_t record_number, const uint16_t* registers,
                                   uint16_t count);
 
+/** Send a FC 23 (0x17) Read Write multiple registers
+ * @param nmbs pointer to the nmbs_t instance
+ * @param read_address starting read address
+ * @param read_quantity quantity of registers to read
+ * @param registers_out array where the read registers will be stored
+ * @param write_address starting write address
+ * @param write_quantity quantity of registers to write
+ * @param registers array of registers values to write
+ *
+ * @return NMBS_ERROR_NONE if successful, other errors otherwise.
+ */
+nmbs_error nmbs_read_write_registers(nmbs_t* nmbs,
+                                     uint16_t read_address,
+                                     uint16_t read_quantity,
+                                     uint16_t* registers_out,
+                                     uint16_t write_address,
+                                     uint16_t write_quantity,
+                                     const uint16_t* registers);
+                                     
 /** Send a raw Modbus PDU.
  * CRC on RTU will be calculated and sent by this function.
  * @param nmbs pointer to the nmbs_t instance

--- a/tests/nanomodbus_tests.c
+++ b/tests/nanomodbus_tests.c
@@ -1045,29 +1045,29 @@ int main(int argc, char* argv[]) {
     UNUSED_PARAM(argc);
     UNUSED_PARAM(argv);
 
-    // for_transports(test_server_create, "create a modbus server");
+    for_transports(test_server_create, "create a modbus server");
 
-    // for_transports(test_server_receive_base, "receive no messages without failing");
+    for_transports(test_server_receive_base, "receive no messages without failing");
 
-    // for_transports(test_fc1, "send and receive FC 01 (0x01) Read Coils");
+    for_transports(test_fc1, "send and receive FC 01 (0x01) Read Coils");
 
-    // for_transports(test_fc2, "send and receive FC 02 (0x02) Read Discrete Inputs");
+    for_transports(test_fc2, "send and receive FC 02 (0x02) Read Discrete Inputs");
 
-    // for_transports(test_fc3, "send and receive FC 03 (0x03) Read Holding Registers");
+    for_transports(test_fc3, "send and receive FC 03 (0x03) Read Holding Registers");
 
-    // for_transports(test_fc4, "send and receive FC 04 (0x04) Read Input Registers");
+    for_transports(test_fc4, "send and receive FC 04 (0x04) Read Input Registers");
 
-    // for_transports(test_fc5, "send and receive FC 05 (0x05) Write Single Coil");
+    for_transports(test_fc5, "send and receive FC 05 (0x05) Write Single Coil");
 
-    // for_transports(test_fc6, "send and receive FC 06 (0x06) Write Single Register");
+    for_transports(test_fc6, "send and receive FC 06 (0x06) Write Single Register");
 
-    // for_transports(test_fc15, "send and receive FC 15 (0x0F) Write Multiple Coils");
+    for_transports(test_fc15, "send and receive FC 15 (0x0F) Write Multiple Coils");
 
-    // for_transports(test_fc16, "send and receive FC 16 (0x10) Write Multiple registers");
+    for_transports(test_fc16, "send and receive FC 16 (0x10) Write Multiple registers");
 
-    // for_transports(test_fc20, "send and receive FC 20 (0x14) Read File Record");
+    for_transports(test_fc20, "send and receive FC 20 (0x14) Read File Record");
 
-    // for_transports(test_fc21, "send and receive FC 21 (0x15) Write File Record");
+    for_transports(test_fc21, "send and receive FC 21 (0x15) Write File Record");
 
     for_transports(test_fc23, "send and receive FC 23 (0x17) Read/Write Multiple Registers");
     return 0;

--- a/tests/nanomodbus_tests.c
+++ b/tests/nanomodbus_tests.c
@@ -1014,7 +1014,7 @@ void test_fc23(nmbs_transport transport) {
     registers_write[2] = 2;
     registers_write[3] = 3;
     check(nmbs_read_write_registers(&CLIENT, 4, 4, registers, 4, 4, registers_write));
-    for(int i = 4; i < 8; i++)
+    for(int i = 0; i < 4; i++)
     {
         expect(registers[i] == registers_write[i]);
     }


### PR DESCRIPTION
Hi,

this mr adds support for fc23, reusing user's read registers and write registers handlers (you don't need a new callback).

I'm not really allowed to spend more effort to clean it up. the code was tested with c++ code in my client project, an incomplete c test is included. 

It also introduce significant code duplication but I think the refactor should be done in a second pass (once fc23 test has been added)

Sorry for the half-effort and thank you