### PR TITLE
Fix a bug where a HANDLE pointer is used instead of HANDLE.

### DIFF
--- a/examples/win32/comm.c
+++ b/examples/win32/comm.c
@@ -93,8 +93,8 @@ bool InitCommPort(HANDLE* hComm, int PortNumber) {
 }
 
 bool CloseCommPort(HANDLE* hComm) {
-    if (hComm != INVALID_HANDLE_VALUE)
-        CloseHandle(hComm);
+    if (*hComm != INVALID_HANDLE_VALUE)
+        CloseHandle(*hComm);
     else
         return false;
 
@@ -104,7 +104,6 @@ bool CloseCommPort(HANDLE* hComm) {
 int32_t ReadCommPort(HANDLE hComm, uint8_t* buf, uint16_t count, int32_t byte_timeout_ms) {
     int TotalBytesRead = 0;
     bool Status = false;
-    bool TimedOut = false;
     ULONGLONG StartTime = 0;
     uint8_t b;
     int tmpByteCount;
@@ -126,7 +125,6 @@ int32_t ReadCommPort(HANDLE hComm, uint8_t* buf, uint16_t count, int32_t byte_ti
 
         // did we time out yet??
         if (GetTickCount64() - StartTime > byte_timeout_ms) {
-            TimedOut = true;
             break;
         }
 


### PR DESCRIPTION
Addressed a minor bug in the win32 example. Both INVALID_HANDLE_VALUE and CloseHandle require a HANDLE instead of a HANDLE*, as outlined in the [Win32 handleapi documentation](https://learn.microsoft.com/en-us/windows/win32/api/handleapi/). 
also removed the unused variable 'TimedOut'.