### PR TITLE
Add more NMBS_CLIENT_DISABLED/NMBS_SERVER_DISABLED #ifndef sections

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -55,9 +55,11 @@ static void discard_1(nmbs_t* nmbs) {
 }
 
 
+#ifndef NMBS_SERVER_DISABLED
 static void discard_n(nmbs_t* nmbs, uint16_t n) {
     nmbs->msg.buf_idx += n;
 }
+#endif
 
 
 static uint16_t get_2(nmbs_t* nmbs) {
@@ -75,15 +77,18 @@ static void put_2(nmbs_t* nmbs, uint16_t data) {
 }
 
 
+#ifndef NMBS_SERVER_DISABLED
 static void set_1(nmbs_t* nmbs, uint8_t data, uint8_t index) {
     nmbs->msg.buf[index] = data;
 }
+
 
 
 static void set_2(nmbs_t* nmbs, uint16_t data, uint8_t index) {
     nmbs->msg.buf[index] = (uint8_t) ((data >> 8) & 0xFFU);
     nmbs->msg.buf[index + 1] = (uint8_t) data;
 }
+#endif
 
 
 static uint8_t* get_n(nmbs_t* nmbs, uint16_t n) {
@@ -92,11 +97,12 @@ static uint8_t* get_n(nmbs_t* nmbs, uint16_t n) {
     return msg_buf_ptr;
 }
 
-
+#ifndef NMBS_SERVER_DISABLED
 static void put_n(nmbs_t* nmbs, const uint8_t* data, uint8_t size) {
     memcpy(&nmbs->msg.buf[nmbs->msg.buf_idx], data, size);
     nmbs->msg.buf_idx += size;
 }
+
 
 
 static uint16_t* get_regs(nmbs_t* nmbs, uint16_t n) {
@@ -107,8 +113,10 @@ static uint16_t* get_regs(nmbs_t* nmbs, uint16_t n) {
     }
     return msg_buf_ptr;
 }
+#endif
 
 
+#ifndef NMBS_CLIENT_DISABLED
 static void put_regs(nmbs_t* nmbs, const uint16_t* data, uint16_t n) {
     uint16_t* msg_buf_ptr = (uint16_t*) (nmbs->msg.buf + nmbs->msg.buf_idx);
     nmbs->msg.buf_idx += n * 2;
@@ -116,6 +124,7 @@ static void put_regs(nmbs_t* nmbs, const uint16_t* data, uint16_t n) {
         msg_buf_ptr[n] = (data[n] << 8) | ((data[n] >> 8) & 0xFF);
     }
 }
+#endif
 
 
 static void swap_regs(uint16_t* data, uint16_t n) {
@@ -358,12 +367,14 @@ static void put_msg_header(nmbs_t* nmbs, uint16_t data_length) {
 }
 
 
+#ifndef NMBS_SERVER_DISABLED
 static void set_msg_header_size(nmbs_t* nmbs, uint16_t data_length) {
     if (nmbs->platform.transport == NMBS_TRANSPORT_TCP) {
         data_length += 2;
         set_2(nmbs, data_length, 4);
     }
 }
+#endif
 
 
 static nmbs_error send_msg(nmbs_t* nmbs) {

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -83,7 +83,6 @@ static void set_1(nmbs_t* nmbs, uint8_t data, uint8_t index) {
 }
 
 
-
 static void set_2(nmbs_t* nmbs, uint16_t data, uint8_t index) {
     nmbs->msg.buf[index] = (uint8_t) ((data >> 8) & 0xFFU);
     nmbs->msg.buf[index + 1] = (uint8_t) data;
@@ -97,12 +96,12 @@ static uint8_t* get_n(nmbs_t* nmbs, uint16_t n) {
     return msg_buf_ptr;
 }
 
+
 #ifndef NMBS_SERVER_DISABLED
 static void put_n(nmbs_t* nmbs, const uint8_t* data, uint8_t size) {
     memcpy(&nmbs->msg.buf[nmbs->msg.buf_idx], data, size);
     nmbs->msg.buf_idx += size;
 }
-
 
 
 static uint16_t* get_regs(nmbs_t* nmbs, uint16_t n) {


### PR DESCRIPTION
Add NMBS_CLIENT_DISABLED/NMBS_SERVER_DISABLED #ifndef to sections, that are client/server specific. This avoids compiler warnings because of unused functions.