### PR TITLE
Make Unknown Functions Reply to Client

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -1832,7 +1832,7 @@ static nmbs_error handle_req_fc(nmbs_t* nmbs) {
             break;
 #endif
         default:
-            err = NMBS_EXCEPTION_ILLEGAL_FUNCTION;
+            err = send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_FUNCTION);
     }
 
     return err;


### PR DESCRIPTION
Changed the default case in `handle_req_fc` to respond instead of silently erroring. This should be done to avoid the connection timing out. 

Most clients expect a response even when the function is unsupported.