### PR TITLE
DE/RE Pin feature

### DIFF
--- a/examples/arduino/client-rtu/client-rtu_DE_RE.ino
+++ b/examples/arduino/client-rtu/client-rtu_DE_RE.ino
@@ -1,0 +1,90 @@
+/*
+   This example client application connects via RTU to a server and sends some requests to it.
+*/
+
+#include "nanomodbus.h"
+
+// The server address
+#define RTU_SERVER_ADDRESS 1
+
+
+int32_t read_serial(uint8_t* buf, uint16_t count, int32_t byte_timeout_ms, void* arg) {
+  Serial.setTimeout(byte_timeout_ms);
+  return Serial.readBytes(buf, count);
+}
+
+
+int32_t write_serial(const uint8_t* buf, uint16_t count, int32_t byte_timeout_ms, void* arg) {
+  Serial.setTimeout(byte_timeout_ms);
+  return Serial.write(buf, count);
+}
+
+
+void onError() {
+  // Make the LED blink on error
+  while (true) {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(1000);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(1000);
+  }
+}
+
+
+void setup() {
+  pinMode (LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+
+  Serial.begin(9600);
+  while (!Serial);
+}
+
+
+void loop() {
+  nmbs_platform_conf platform_conf;
+  platform_conf.transport = NMBS_TRANSPORT_RTU;
+  platform_conf.read = read_serial;
+  platform_conf.write = write_serial;
+
+  nmbs_t nmbs;
+  nmbs_error err = nmbs_client_create(&nmbs, &platform_conf);
+  if (err != NMBS_ERROR_NONE)
+    onError();
+
+  nmbs_set_read_timeout(&nmbs, 1000);
+  nmbs_set_byte_timeout(&nmbs, 100);
+
+  nmbs_set_destination_rtu_address(&nmbs, RTU_SERVER_ADDRESS);
+
+  // Write 2 coils from address 64
+  nmbs_bitfield coils = {0};
+  nmbs_bitfield_write(coils, 0, 1);
+  nmbs_bitfield_write(coils, 1, 1);
+  err = nmbs_write_multiple_coils(&nmbs, 64, 2, coils);
+  if (err != NMBS_ERROR_NONE)
+    onError();
+
+  // Read 3 coils from address 64
+  nmbs_bitfield_reset(coils);    // Reset whole bitfield to zero
+  err = nmbs_read_coils(&nmbs, 64, 3, coils);
+  if (err != NMBS_ERROR_NONE)
+    onError();
+
+  // Write 2 holding registers at address 26
+  uint16_t w_regs[2] = {123, 124};
+  err = nmbs_write_multiple_registers(&nmbs, 26, 2, w_regs);
+  if (err != NMBS_ERROR_NONE)
+    onError();
+
+  // Read 2 holding registers from address 26
+  uint16_t r_regs[2];
+  err = nmbs_read_holding_registers(&nmbs, 26, 2, r_regs);
+  if (err != NMBS_ERROR_NONE)
+    onError();
+
+  // On success, keep the led on
+  digitalWrite(LED_BUILTIN, HIGH);
+
+  // No need to destroy the nmbs instance, terminate the program
+  exit(0);
+}

--- a/examples/arduino/server-rtu/server-rtu_DE_RE.ino
+++ b/examples/arduino/server-rtu/server-rtu_DE_RE.ino
@@ -1,0 +1,154 @@
+/*
+   This example application sets up an RTU server and handles modbus requests
+
+   This server supports the following function codes:
+   FC 01 (0x01) Read Coils
+   FC 03 (0x03) Read Holding Registers
+   FC 15 (0x0F) Write Multiple Coils
+   FC 16 (0x10) Write Multiple registers
+*/
+
+#include "nanomodbus.h"
+
+#define DE_RE_Pin 13
+// The data model of this sever will support coils addresses 0 to 100 and registers addresses from 0 to 32
+#define COILS_ADDR_MAX 100
+#define REGS_ADDR_MAX 32
+
+// Our RTU address
+#define RTU_SERVER_ADDRESS 1
+
+// A single nmbs_bitfield variable can keep 2000 coils
+nmbs_bitfield server_coils = {0};
+uint16_t server_registers[REGS_ADDR_MAX] = {0};
+
+
+void ResetDE()
+{
+    digitalWrite(DE_RE_Pin, LOW);
+}
+
+void SetDE()
+{
+    digitalWrite(DE_RE_Pin, HIGH);
+}
+
+int32_t read_serial(uint8_t* buf, uint16_t count, int32_t byte_timeout_ms, void* arg) {
+  Serial.setTimeout(byte_timeout_ms);
+  return Serial.readBytes(buf, count);
+}
+
+
+int32_t write_serial(const uint8_t* buf, uint16_t count, int32_t byte_timeout_ms, void* arg) {
+  Serial.setTimeout(byte_timeout_ms);
+  return Serial.write(buf, count);
+}
+
+
+void onError() {
+  // Set the led ON on error
+  while (true) {
+    digitalWrite(LED_BUILTIN, HIGH);
+  }
+}
+
+
+nmbs_error handle_read_coils(uint16_t address, uint16_t quantity, nmbs_bitfield coils_out, uint8_t unit_id, void *arg) {
+  if (address + quantity > COILS_ADDR_MAX + 1)
+    return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
+
+  // Read our coils values into coils_out
+  for (int i = 0; i < quantity; i++) {
+    bool value = nmbs_bitfield_read(server_coils, address + i);
+    nmbs_bitfield_write(coils_out, i, value);
+  }
+
+  return NMBS_ERROR_NONE;
+}
+
+
+nmbs_error handle_write_multiple_coils(uint16_t address, uint16_t quantity, const nmbs_bitfield coils, uint8_t unit_id, void *arg) {
+  if (address + quantity > COILS_ADDR_MAX + 1)
+    return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
+
+  // Write coils values to our server_coils
+  for (int i = 0; i < quantity; i++) {
+    nmbs_bitfield_write(server_coils, address + i, nmbs_bitfield_read(coils, i));
+  }
+
+  return NMBS_ERROR_NONE;
+}
+
+
+nmbs_error handler_read_holding_registers(uint16_t address, uint16_t quantity, uint16_t* registers_out, uint8_t unit_id, void *arg) {
+  if (address + quantity > REGS_ADDR_MAX + 1)
+    return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
+
+  // Read our registers values into registers_out
+  for (int i = 0; i < quantity; i++)
+    registers_out[i] = server_registers[address + i];
+
+  return NMBS_ERROR_NONE;
+}
+
+
+nmbs_error handle_write_multiple_registers(uint16_t address, uint16_t quantity, const uint16_t* registers, uint8_t unit_id, void *arg) {
+  if (address + quantity > REGS_ADDR_MAX + 1)
+    return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS;
+
+  // Write registers values to our server_registers
+  for (int i = 0; i < quantity; i++)
+    server_registers[address + i] = registers[i];
+
+  return NMBS_ERROR_NONE;
+}
+
+
+void setup() {
+  pinMode (LED_BUILTIN, OUTPUT);
+
+  Serial.begin(9600);
+  while (!Serial);
+}
+
+
+void loop() {
+  nmbs_platform_conf platform_conf;
+  platform_conf.transport = NMBS_TRANSPORT_RTU;
+  platform_conf.read = read_serial;
+  platform_conf.write = write_serial;
+  platform_conf.arg = NULL;
+  platform_conf.ResetDE_pin = ResetDE;
+  platform_conf.SetDE_pin = SetDE;
+
+  nmbs_callbacks callbacks = {0};
+  callbacks.read_coils = handle_read_coils;
+  callbacks.write_multiple_coils = handle_write_multiple_coils;
+  callbacks.read_holding_registers = handler_read_holding_registers;
+  callbacks.write_multiple_registers = handle_write_multiple_registers;
+
+  // Create the modbus server
+  nmbs_t nmbs;
+  nmbs_error err = nmbs_server_create(&nmbs, RTU_SERVER_ADDRESS, &platform_conf, &callbacks);
+  if (err != NMBS_ERROR_NONE) {
+    onError();
+  }
+
+  nmbs_set_read_timeout(&nmbs, 1000);
+  nmbs_set_byte_timeout(&nmbs, 100);
+
+  bool led = false;
+
+  while (true) {
+    err = nmbs_server_poll(&nmbs);
+    // This will probably never happen, since we don't return < 0 in our platform funcs
+    if (err == NMBS_ERROR_TRANSPORT)
+      break;
+
+    digitalWrite(LED_BUILTIN, led);
+    led = !led;
+  }
+
+  // No need to destroy the nmbs instance, terminate the program
+  exit(0);
+}

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -146,6 +146,7 @@ static void msg_state_reset(nmbs_t* nmbs) {
     nmbs->msg.transaction_id = 0;
     nmbs->msg.broadcast = false;
     nmbs->msg.ignored = false;
+    nmbs->platform.ResetDE_pin();//-----------------added by PM------------------------//
 }
 
 
@@ -250,10 +251,12 @@ static nmbs_error recv(nmbs_t* nmbs, uint16_t count) {
 
 
 static nmbs_error send(nmbs_t* nmbs, uint16_t count) {
+    nmbs->platform.SetDE_pin();//-----------------added by PM------------------------//
     int32_t ret = nmbs->platform.write(nmbs->msg.buf, count, nmbs->byte_timeout_ms, nmbs->platform.arg);
 
-    if (ret == count)
+    if (ret == count){
         return NMBS_ERROR_NONE;
+    }
 
     if (ret < count) {
         if (ret < 0)

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -149,6 +149,8 @@ typedef struct nmbs_platform_conf {
     int32_t (*write)(const uint8_t* buf, uint16_t count, int32_t byte_timeout_ms,
                      void* arg); /*!< Bytes write transport function pointer */
     void* arg;                   /*!< User data, will be passed to functions above */
+    void (*ResetDE_pin)(void);//-----------------added by PM------------------------//
+    void (*SetDE_pin)(void);//-----------------added by PM------------------------//
 } nmbs_platform_conf;
 
 


### PR DESCRIPTION
Now this library can be used with RS485 ic MAX485CSA+ or similar. these ICs have DE and RE pins that should be handled properly to enable the transmission, now this library can handle that on any GPIO.

client-rtu_DE_RE.ino and server-rtu_DE_RE.ino examples have been added to explain the uses.