### PR TITLE
resolve segment fault and Error on modbus connection

### DIFF
--- a/examples/linux/platform.h
+++ b/examples/linux/platform.h
@@ -167,6 +167,7 @@ void disconnect(void* conn) {
 // Read/write/sleep platform functions
 
 int32_t read_fd_linux(uint8_t* buf, uint16_t count, int32_t timeout_ms, void* arg) {
+    if(!arg) return -1;
     int fd = *(int*) arg;
 
     uint16_t total = 0;
@@ -192,7 +193,7 @@ int32_t read_fd_linux(uint8_t* buf, uint16_t count, int32_t timeout_ms, void* ar
             ssize_t r = read(fd, buf + total, 1);
             if (r == 0) {
                 disconnect(arg);
-                return -1;
+                return 0;
             }
 
             if (r < 0)

--- a/examples/linux/server-tcp.c
+++ b/examples/linux/server-tcp.c
@@ -218,6 +218,8 @@ int main(int argc, char* argv[]) {
         if (conn) {
             // Set the next connection handler used by the read/write platform functions
             nmbs_set_platform_arg(&nmbs, conn);
+        }else{
+            continue;
         }
 
         err = nmbs_server_poll(&nmbs);


### PR DESCRIPTION
Now, run ./server-tcp localhost 9000 you won't get core dump and error message.