### PR TITLE
Flush TCP socket on exception

### DIFF
--- a/examples/linux/client-tcp.c
+++ b/examples/linux/client-tcp.c
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
     uint16_t w_regs[2] = {123, 124};
     err = nmbs_write_multiple_registers(&nmbs, 26, 2, w_regs);
     if (err != NMBS_ERROR_NONE) {
-        fprintf(stderr, "Error writing register at address 26 - %s", nmbs_strerror(err));
+        fprintf(stderr, "Error writing register at address 26 - %s\n", nmbs_strerror(err));
         if (!nmbs_error_is_exception(err))
             return 1;
     }

--- a/examples/linux/platform.h
+++ b/examples/linux/platform.h
@@ -236,7 +236,7 @@ int32_t write_fd_linux(const uint8_t* buf, uint16_t count, int32_t timeout_ms, v
         }
 
         if (ret == 1) {
-            ssize_t w = write(fd, buf + total, count);
+            ssize_t w = write(fd, buf + total, count - total);
             if (w == 0) {
                 disconnect(arg);
                 return -1;

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -239,6 +239,7 @@ typedef struct nmbs_t {
         uint8_t unit_id;
         uint8_t fc;
         uint16_t transaction_id;
+        uint16_t length;         // only valid for NMBS_TRANSPORT_TCP
         bool broadcast;
         bool ignored;
     } msg;


### PR DESCRIPTION
Not all bytes may have been read from the TCP socket read buffer when the request processing is aborted by an exception.

- remember the frame length from the message header
- derease remaining length on every successful read
- after sending the exception flush any remaining bytes from the socket

Fixes #67