### PR TITLE
Fix comipler error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_definitions(client_disabled PUBLIC NMBS_CLIENT_DISABLED)
 
 add_executable(multi_server_rtu nanomodbus.c tests/multi_server_rtu.c)
 target_compile_definitions(multi_server_rtu PUBLIC NMBS_DEBUG)
+target_link_libraries(multi_server_rtu pthread)
 
 add_custom_target(tests DEPENDS nanomodbus_tests server_disabled client_disabled multi_server_rtu)
 


### PR DESCRIPTION
Fix comipler error on ``Linux localhost.localdomain 3.10.0-1160.71.1.el7.x86_64`` with undefined reference to `pthread_xxx` function.
![2024-10-12 09 52 05](https://github.com/user-attachments/assets/0e3ee36a-9079-418d-91dd-fdf07810371b)
