### PR TITLE
_MSC_VER support for C

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -1319,7 +1319,7 @@ static nmbs_error handle_read_file_record(nmbs_t* nmbs) {
         uint16_t record_number;
         uint16_t record_length;
     }
-#ifdef __STDC_NO_VLA__
+#if defined(__STDC_NO_VLA__) || defined(_MSC_VER)
     subreq[35];    // 245 / subreq_header_size
 #else
     subreq[subreq_count];
@@ -1537,7 +1537,7 @@ static nmbs_error handle_read_write_registers(nmbs_t* nmbs) {
     if (err != NMBS_ERROR_NONE)
         return err;
 
-#ifdef __STDC_NO_VLA__
+#if defined(__STDC_NO_VLA__) || defined(_MSC_VER)
     uint16_t registers[0x007B];
 #else
     uint16_t registers[byte_count_write / 2];
@@ -1580,7 +1580,7 @@ static nmbs_error handle_read_write_registers(nmbs_t* nmbs) {
         }
 
         if (!nmbs->msg.broadcast) {
-#ifdef __STDC_NO_VLA__
+#if defined(__STDC_NO_VLA__) || defined(_MSC_VER)
             uint16_t regs[125];
 #else
             uint16_t regs[read_quantity];


### PR DESCRIPTION
I could not compile nanoMODBUS in Visual Studio Community 2022 with C++ compiler, due to lack of `__STDC_NO_VLA__`.
Instead, I have added this:

```
#if defined(__STDC_NO_VLA__) || defined(_MSC_VER)
```
From this:

```
#ifdef __STDC_NO_VLA__
```

This is done for every `#ifdef __STDC_NO_VLA__`. 
