### PR TITLE
rtu: support server handling all unit id requests

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -438,6 +438,8 @@ static nmbs_error recv_req_header(nmbs_t* nmbs, bool* first_byte_received) {
         // Check if request is for us
         if (nmbs->msg.unit_id == NMBS_BROADCAST_ADDRESS)
             nmbs->msg.broadcast = true;
+        else if (nmbs->address_rtu == 255)
+            nmbs->msg.ignored = false;
         else if (nmbs->msg.unit_id != nmbs->address_rtu)
             nmbs->msg.ignored = true;
         else

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -297,7 +297,7 @@ void nmbs_callbacks_create(nmbs_callbacks* callbacks);
 
 /** Create a new Modbus server.
  * @param nmbs pointer to the nmbs_t instance where the client will be created.
- * @param address_rtu RTU address of this server. Can be 0 if transport is not RTU.
+ * @param address_rtu RTU address of this server (255 will accept all requests). Can be 0 if transport is not RTU.
  * @param platform_conf nmbs_platform_conf struct with platform configuration. It may be discarded after calling this method.
  * @param callbacks nmbs_callbacks struct with server request callbacks. It may be discarded after calling this method.
  *


### PR DESCRIPTION
Currently we only process requests that match our 'address_rtu'. Add a special 'address_rtu' value of 255 to allow processing all received client requests.