### PR TITLE
optimized  nmbs_bitfield macros a little 

### DIFF
--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -92,23 +92,23 @@ typedef uint8_t nmbs_bitfield_256[32];
 /**
  * Read a bit from the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_read(bf, b) ((bool) ((bf)[(b) / 8] & (0x1 << ((b) % 8))))
+#define nmbs_bitfield_read(bf, b) ((bool) ((bf)[(b) >> 3] & (0x1 << ((b) & (8 - 1)))))
 
 /**
  * Set a bit of the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_set(bf, b) (((bf)[(b) / 8]) = (((bf)[(b) / 8]) | (0x1 << ((b) % 8))))
+#define nmbs_bitfield_set(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) | (0x1 << ((b) & (8 - 1)))))
 
 /**
  * Reset a bit of the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_unset(bf, b) (((bf)[(b) / 8]) = (((bf)[(b) / 8]) & ~(0x1 << ((b) % 8))))
+#define nmbs_bitfield_unset(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) & ~(0x1 << ((b) & (8 - 1)))))
 
 /**
  * Write value v to the nmbs_bitfield bf at position b
  */
 #define nmbs_bitfield_write(bf, b, v)                                                                                  \
-    (((bf)[(b) / 8]) = ((v) ? (((bf)[(b) / 8]) | (0x1 << ((b) % 8))) : (((bf)[(b) / 8]) & ~(0x1 << ((b) % 8)))))
+    (((bf)[(b) >> 3]) = ((v) ? (((bf)[(b) >> 3]) | (0x1 << ((b) & (8 - 1)))) : (((bf)[(b) >> 3]) & ~(0x1 << ((b) & (8 - 1))))))
 
 /**
  * Reset (zero) the whole bitfield

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -92,17 +92,17 @@ typedef uint8_t nmbs_bitfield_256[32];
 /**
  * Read a bit from the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_read(bf, b) ((bool) ((bf)[(b) >> 3] & (0x1 << ((b) & 7))))
+#define nmbs_bitfield_read(bf, b) ((bool) ((bf)[(b) >> 3] & (0x1 << ((b) & (8 - 1)))))
 
 /**
  * Set a bit of the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_set(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) | (0x1 << ((b) & 7))))
+#define nmbs_bitfield_set(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) | (0x1 << ((b) & (8 - 1)))))
 
 /**
  * Reset a bit of the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_unset(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) & ~(0x1 << ((b) & 7))))
+#define nmbs_bitfield_unset(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) & ~(0x1 << ((b) & (8 - 1)))))
 
 /**
  * Write value v to the nmbs_bitfield bf at position b

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -92,24 +92,22 @@ typedef uint8_t nmbs_bitfield_256[32];
 /**
  * Read a bit from the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_read(bf, b) ((bool) ((bf)[(b) >> 3] & (0x1 << ((b) & (8 - 1)))))
+#define nmbs_bitfield_read(bf, b) ((bool) ((bf)[(b) >> 3] & (0x1 << ((b) & 7))))
 
 /**
  * Set a bit of the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_set(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) | (0x1 << ((b) & (8 - 1)))))
+#define nmbs_bitfield_set(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) | (0x1 << ((b) & 7))))
 
 /**
  * Reset a bit of the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_unset(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) & ~(0x1 << ((b) & (8 - 1)))))
+#define nmbs_bitfield_unset(bf, b) (((bf)[(b) >> 3]) = (((bf)[(b) >> 3]) & ~(0x1 << ((b) & 7))))
 
 /**
  * Write value v to the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_write(bf, b, v)                                                                                  \
-    (((bf)[(b) >> 3]) = ((v) ? (((bf)[(b) >> 3]) | (0x1 << ((b) & (8 - 1)))) : (((bf)[(b) >> 3]) & ~(0x1 << ((b) & (8 - 1))))))
-
+#define nmbs_bitfield_write(bf, b, v) ((bf)[(b) >> 3] = ((bf)[(b) >> 3] & ~(1 << ((b) & 7))) | ((v) << ((b) & 7)))
 /**
  * Reset (zero) the whole bitfield
  */


### PR DESCRIPTION
Replaced division/mod operations with bitwise shifts (>> 3, & 7) for better performance on MCUs in the following macros

- nmbs_bitfield_reset
- nmbs_bitfield_write
- nmbs_bitfield_unset
- nmbs_bitfield_set
- nmbs_bitfield_read