### PR TITLE
Fix small issue in Write File Record server response

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -1513,10 +1513,6 @@ static nmbs_error handle_write_file_record(nmbs_t* nmbs) {
 
         if (!nmbs->msg.broadcast) {
             // The normal response to 'Write File' is an echo of the request.
-            // We can restore buffer index and response msg.
-            nmbs->msg.buf_idx = msg_buf_idx;
-            discard_n(nmbs, request_size);
-
             err = send_msg(nmbs);
             if (err != NMBS_ERROR_NONE)
                 return err;


### PR DESCRIPTION
According to the official MODBUS protocol documentation the normal response is an echo of the request. The whole request including the records data must be included in the response. This pull request makes sure the whole request is send as a response. 

Link to the MODBUS documentation for reference: https://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf