### PR TITLE
Read Device Identification Regular Object Id 0x07

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -1734,9 +1734,9 @@ static nmbs_error handle_read_device_identification(nmbs_t* nmbs) {
                     last_id = 0x02;
                     break;
                 case 2:
-                    if (object_id < 0x03 || object_id > 0x07)
+                    if (object_id < 0x03 || object_id > 0x06)
                         return send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
-                    last_id = 0x07;
+                    last_id = 0x06;
                     break;
                 case 3:
                     if (object_id < 0x80)


### PR DESCRIPTION
In MODBUS APPLICATION PROTOCOL SPECIFICATION V1.1b3 Regular Object Id 0x07 of Read Device Identification is Reserved and should therefore be responded to with a NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS.