### PR TITLE
Add custom flush function feature

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,17 @@
 {
     "version": "0.2.0",
     "configurations": [
-       // Use the CMake panel to launch/debug
+        {
+            "name": "Debug active CMake target",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb"
+        }
     ]
 }

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -242,14 +242,14 @@ nmbs_error nmbs_create(nmbs_t* nmbs, const nmbs_platform_conf* platform_conf) {
     if (!platform_conf->read || !platform_conf->write)
         return NMBS_ERROR_INVALID_ARGUMENT;
 
+    nmbs->platform = *platform_conf;
+
     if (!platform_conf->flush) {
         nmbs->platform.flush = flush;
     }
     else {
         nmbs->platform.flush = platform_conf->flush;    // allow custom flush implementation
     }
-
-    nmbs->platform = *platform_conf;
 
     return NMBS_ERROR_NONE;
 }

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -183,8 +183,8 @@ static nmbs_error send(const nmbs_t* nmbs, uint16_t count) {
 }
 
 
-static void flush(nmbs_t* nmbs) {
-    nmbs->platform.read(nmbs->msg.buf, sizeof(nmbs->msg.buf), 0, nmbs->platform.arg);
+static int32_t flush(nmbs_t* nmbs) {
+    return nmbs->platform.read(nmbs->msg.buf, sizeof(nmbs->msg.buf), 0, nmbs->platform.arg);
 }
 
 
@@ -241,6 +241,13 @@ nmbs_error nmbs_create(nmbs_t* nmbs, const nmbs_platform_conf* platform_conf) {
 
     if (!platform_conf->read || !platform_conf->write)
         return NMBS_ERROR_INVALID_ARGUMENT;
+
+    if (!platform_conf->flush) {
+        nmbs->platform.flush = flush;
+    }
+    else {
+        nmbs->platform.flush = platform_conf->flush;    // allow custom flush implementation
+    }
 
     nmbs->platform = *platform_conf;
 

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -244,13 +244,6 @@ nmbs_error nmbs_create(nmbs_t* nmbs, const nmbs_platform_conf* platform_conf) {
 
     nmbs->platform = *platform_conf;
 
-    if (!platform_conf->flush) {
-        nmbs->platform.flush = flush;
-    }
-    else {
-        nmbs->platform.flush = platform_conf->flush;    // allow custom flush implementation
-    }
-
     return NMBS_ERROR_NONE;
 }
 
@@ -268,6 +261,7 @@ void nmbs_set_byte_timeout(nmbs_t* nmbs, int32_t timeout_ms) {
 void nmbs_platform_conf_create(nmbs_platform_conf* platform_conf) {
     memset(platform_conf, 0, sizeof(nmbs_platform_conf));
     platform_conf->crc_calc = nmbs_crc_calc;
+    platform_conf->flush = flush;
     // Workaround for older user code not calling nmbs_platform_conf_create()
     platform_conf->initialized = 0xFFFFDEBE;
 }

--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -212,7 +212,7 @@ static void msg_state_req(nmbs_t* nmbs, uint8_t fc) {
         nmbs->current_tid++;
 
     // Flush the remaining data on the line before sending the request
-    flush(nmbs);
+    nmbs->platform.flush(nmbs);
 
     msg_state_reset(nmbs);
     nmbs->msg.unit_id = nmbs->dest_address_rtu;
@@ -1891,7 +1891,7 @@ static nmbs_error handle_req_fc(nmbs_t* nmbs) {
             break;
 #endif
         default:
-            flush(nmbs);
+            nmbs->platform.flush(nmbs);
             if (!nmbs->msg.ignored)
                 err = send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_FUNCTION);
     }
@@ -1951,7 +1951,7 @@ nmbs_error nmbs_server_poll(nmbs_t* nmbs) {
     err = handle_req_fc(nmbs);
     if (err != NMBS_ERROR_NONE) {
         if (err != NMBS_ERROR_TIMEOUT)
-            flush(nmbs);
+            nmbs->platform.flush(nmbs);
 
         return err;
     }

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -48,6 +48,8 @@
 extern "C" {
 #endif
 
+typedef struct nmbs_t nmbs_t;
+
 /**
  * nanoMODBUS errors.
  * Values <= 0 are library errors, > 0 are modbus exceptions.
@@ -117,7 +119,7 @@ typedef uint8_t nmbs_bitfield_256[32];
 /**
  * Write value v to the nmbs_bitfield bf at position b
  */
-#define nmbs_bitfield_write(bf, b, v) ((bf)[(b) >> 3] = ((bf)[(b) >> 3] & ~(1 << ((b) & 7))) | ((v) << ((b) & 7)))
+#define nmbs_bitfield_write(bf, b, v) ((bf)[(b) >> 3] = ((bf)[(b) >> 3] & ~(1 << ((b) &7))) | ((v) << ((b) &7)))
 /**
  * Reset (zero) the whole bitfield
  */
@@ -163,7 +165,8 @@ typedef struct nmbs_platform_conf {
                      void* arg); /*!< Bytes write transport function pointer */
     uint16_t (*crc_calc)(const uint8_t* data, uint32_t length,
                          void* arg); /*!< CRC calculation function pointer. Optional */
-    void* arg;                       /*!< User data, will be passed to functions above */
+    int32_t (*flush)(nmbs_t* nmbs);
+    void* arg;            /*!< User data, will be passed to functions above */
     uint32_t initialized; /*!< Reserved, workaround for older user code not calling nmbs_platform_conf_create() */
 } nmbs_platform_conf;
 
@@ -241,7 +244,7 @@ typedef struct nmbs_callbacks {
  * nanoMODBUS client/server instance type. All struct members are to be considered private,
  * it is not advisable to read/write them directly.
  */
-typedef struct nmbs_t {
+struct nmbs_t {
     struct {
         uint8_t buf[260];
         uint16_t buf_idx;
@@ -264,7 +267,7 @@ typedef struct nmbs_t {
     uint8_t address_rtu;
     uint8_t dest_address_rtu;
     uint16_t current_tid;
-} nmbs_t;
+};
 
 /**
  * Modbus broadcast address. Can be passed to nmbs_set_destination_rtu_address().

--- a/tests/nanomodbus_tests.c
+++ b/tests/nanomodbus_tests.c
@@ -233,15 +233,15 @@ void test_fc1(nmbs_transport transport) {
     expect(nmbs_read_coils(&CLIENT, 65530, 7, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(65530), htons(7)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(65530), htons(7)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -279,11 +279,11 @@ void test_fc1(nmbs_transport transport) {
         expect(nmbs_read_coils(&CLIENT, 2, 1, bf) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -320,15 +320,15 @@ void test_fc2(nmbs_transport transport) {
     expect(nmbs_read_discrete_inputs(&CLIENT, 65530, 7, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(65530), htons(7)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(65530), htons(7)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -366,11 +366,11 @@ void test_fc2(nmbs_transport transport) {
         expect(nmbs_read_discrete_inputs(&CLIENT, 2, 1, bf) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -445,15 +445,15 @@ void test_fc3(nmbs_transport transport) {
     expect(nmbs_read_holding_registers(&CLIENT, 0xFFFF, 2, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -479,11 +479,11 @@ void test_fc3(nmbs_transport transport) {
         expect(nmbs_read_holding_registers(&CLIENT, 2, 1, regs) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -520,15 +520,15 @@ void test_fc4(nmbs_transport transport) {
     expect(nmbs_read_input_registers(&CLIENT, 0xFFFF, 2, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -554,11 +554,11 @@ void test_fc4(nmbs_transport transport) {
         expect(nmbs_read_input_registers(&CLIENT, 2, 1, regs) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -612,10 +612,10 @@ void test_fc5(nmbs_transport transport) {
     nmbs_set_callbacks_arg(&SERVER, (void*) &callbacks_user_data);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE when calling with value not 0x0000 or 0xFF000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(6), htons(0x0001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(6), htons(0x0001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(6), htons(0xFFFF)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(6), htons(0xFFFF)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -632,7 +632,7 @@ void test_fc5(nmbs_transport transport) {
     check(nmbs_write_single_coil(&CLIENT, 5, false));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0xFF00)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0xFF00)}, 4));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(4));
@@ -645,11 +645,11 @@ void test_fc5(nmbs_transport transport) {
         expect(nmbs_write_single_coil(&CLIENT, 2, true) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(2), htons(0x00FF)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(2), htons(0x00FF)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0x0000)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0x0000)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -716,7 +716,7 @@ void test_fc6(nmbs_transport transport) {
     check(nmbs_write_single_register(&CLIENT, 5, 0));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0x123)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0x123)}, 4));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(4));
@@ -729,11 +729,11 @@ void test_fc6(nmbs_transport transport) {
         expect(nmbs_write_single_register(&CLIENT, 2, 123) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(2), htons(0x123)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(2), htons(0x123)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0x123)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0x123)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -819,15 +819,15 @@ void test_fc15(nmbs_transport transport) {
     expect(nmbs_write_multiple_coils(&CLIENT, 0xFFFF, 2, bf) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0), htons(0x0100)}, 6));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2000), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2000), htons(0x0100)}, 6));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2), htons(0x0100)}, 6));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     /*
@@ -856,7 +856,7 @@ void test_fc15(nmbs_transport transport) {
     check(nmbs_write_multiple_coils(&CLIENT, 5, 27, bf));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(7), htons(1), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(7), htons(1), htons(0x0100)}, 6));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(7));
@@ -869,11 +869,11 @@ void test_fc15(nmbs_transport transport) {
         expect(nmbs_write_multiple_coils(&CLIENT, 2, 2, bf) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(1), htons(0x0100)}, 6));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(1), htons(0x0100)}, 6));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(1), htons(0x0100)}, 6));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(1), htons(0x0100)}, 6));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -959,16 +959,15 @@ void test_fc16(nmbs_transport transport) {
     expect(nmbs_write_multiple_registers(&CLIENT, 0xFFFF, 2, registers) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0), htons(0x0200), htons(0)}, 7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0), htons(0x0200), htons(0)}, 7));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2000), htons(0x0200), htons(0)}, 7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2000), htons(0x0200), htons(0)}, 7));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2), htons(0x0200), htons(0)},
-                            7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2), htons(0x0200), htons(0)}, 7));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     /*
@@ -997,7 +996,7 @@ void test_fc16(nmbs_transport transport) {
     check(nmbs_write_multiple_registers(&CLIENT, 6, 27, registers));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(7), htons(1), htons(0x0200), htons(0)}, 7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(7), htons(1), htons(0x0200), htons(0)}, 7));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(7));
@@ -1010,12 +1009,12 @@ void test_fc16(nmbs_transport transport) {
         expect(nmbs_write_multiple_registers(&CLIENT, 2, 2, registers) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2000), htons(0x0200), htons(0)},
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2000), htons(0x0200), htons(0)},
                                 7));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(7), htons(1), htons(0x0200), htons(0)}, 7));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(7), htons(1), htons(0x0200), htons(0)}, 7));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -1378,35 +1377,35 @@ void test_fc43_14(nmbs_transport transport) {
     nmbs_set_callbacks_arg(&SERVER, (void*) &callbacks_user_data);
 
     should("return NMBS_EXCEPTION_ILLEGAL_FUNCTION with wrong MEI type");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {69, 1, 0}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){69, 1, 0}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_FUNCTION);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE with wrong Read Device ID code");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 0, 0}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 0, 0}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE with wrong Read Device ID code");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 5, 0}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 5, 0}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with reserved Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 1, 0x07}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 1, 0x07}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with reserved Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 4, 0x07}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 4, 0x07}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with out of range Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 1, 0x03}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 1, 0x03}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with out of range Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 2, 0x01}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 2, 0x01}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with out of range Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 3, 0x02}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 3, 0x02}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("read basic object ids with no error");
@@ -1451,7 +1450,7 @@ void test_fc43_14(nmbs_transport transport) {
                                                         &objects_count) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 3, 0x02}, 3);
+        nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 3, 0x02}, 3);
         expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_ERROR_TIMEOUT);
     }
 

--- a/tests/nanomodbus_tests.c
+++ b/tests/nanomodbus_tests.c
@@ -233,15 +233,15 @@ void test_fc1(nmbs_transport transport) {
     expect(nmbs_read_coils(&CLIENT, 65530, 7, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(65530), htons(7)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(65530), htons(7)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -279,11 +279,11 @@ void test_fc1(nmbs_transport transport) {
         expect(nmbs_read_coils(&CLIENT, 2, 1, bf) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -320,15 +320,15 @@ void test_fc2(nmbs_transport transport) {
     expect(nmbs_read_discrete_inputs(&CLIENT, 65530, 7, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(65530), htons(7)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(65530), htons(7)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -366,11 +366,11 @@ void test_fc2(nmbs_transport transport) {
         expect(nmbs_read_discrete_inputs(&CLIENT, 2, 1, bf) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -445,15 +445,15 @@ void test_fc3(nmbs_transport transport) {
     expect(nmbs_read_holding_registers(&CLIENT, 0xFFFF, 2, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -479,11 +479,11 @@ void test_fc3(nmbs_transport transport) {
         expect(nmbs_read_holding_registers(&CLIENT, 2, 1, regs) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -520,15 +520,15 @@ void test_fc4(nmbs_transport transport) {
     expect(nmbs_read_input_registers(&CLIENT, 0xFFFF, 2, NULL) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -554,11 +554,11 @@ void test_fc4(nmbs_transport transport) {
         expect(nmbs_read_input_registers(&CLIENT, 2, 1, regs) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2001)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2001)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(10), htons(3)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(10), htons(3)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -612,10 +612,10 @@ void test_fc5(nmbs_transport transport) {
     nmbs_set_callbacks_arg(&SERVER, (void*) &callbacks_user_data);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE when calling with value not 0x0000 or 0xFF000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(6), htons(0x0001)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(6), htons(0x0001)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(6), htons(0xFFFF)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(6), htons(0xFFFF)}, 4));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE when server handler returns any non-exception error");
@@ -632,7 +632,7 @@ void test_fc5(nmbs_transport transport) {
     check(nmbs_write_single_coil(&CLIENT, 5, false));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0xFF00)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0xFF00)}, 4));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(4));
@@ -645,11 +645,11 @@ void test_fc5(nmbs_transport transport) {
         expect(nmbs_write_single_coil(&CLIENT, 2, true) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(2), htons(0x00FF)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(2), htons(0x00FF)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0x0000)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0x0000)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -716,7 +716,7 @@ void test_fc6(nmbs_transport transport) {
     check(nmbs_write_single_register(&CLIENT, 5, 0));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0x123)}, 4));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0x123)}, 4));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(4));
@@ -729,11 +729,11 @@ void test_fc6(nmbs_transport transport) {
         expect(nmbs_write_single_register(&CLIENT, 2, 123) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(2), htons(0x123)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(2), htons(0x123)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(0x123)}, 4));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(0x123)}, 4));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -819,15 +819,15 @@ void test_fc15(nmbs_transport transport) {
     expect(nmbs_write_multiple_coils(&CLIENT, 0xFFFF, 2, bf) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0), htons(0x0100)}, 6));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2000), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2000), htons(0x0100)}, 6));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2), htons(0x0100)}, 6));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     /*
@@ -856,7 +856,7 @@ void test_fc15(nmbs_transport transport) {
     check(nmbs_write_multiple_coils(&CLIENT, 5, 27, bf));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(7), htons(1), htons(0x0100)}, 6));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(7), htons(1), htons(0x0100)}, 6));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(7));
@@ -869,11 +869,11 @@ void test_fc15(nmbs_transport transport) {
         expect(nmbs_write_multiple_coils(&CLIENT, 2, 2, bf) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(1), htons(0x0100)}, 6));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(1), htons(0x0100)}, 6));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(4), htons(1), htons(0x0100)}, 6));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(4), htons(1), htons(0x0100)}, 6));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -959,15 +959,16 @@ void test_fc16(nmbs_transport transport) {
     expect(nmbs_write_multiple_registers(&CLIENT, 0xFFFF, 2, registers) == NMBS_ERROR_INVALID_ARGUMENT);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity 0");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0), htons(0x0200), htons(0)}, 7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(0), htons(0x0200), htons(0)}, 7));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2000), htons(0x0200), htons(0)}, 7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2000), htons(0x0200), htons(0)}, 7));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(0xFFFF), htons(2), htons(0x0200), htons(0)}, 7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(0xFFFF), htons(2), htons(0x0200), htons(0)},
+                            7));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     /*
@@ -996,7 +997,7 @@ void test_fc16(nmbs_transport transport) {
     check(nmbs_write_multiple_registers(&CLIENT, 6, 27, registers));
 
     should("echo request's address and value");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(7), htons(1), htons(0x0200), htons(0)}, 7));
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(7), htons(1), htons(0x0200), htons(0)}, 7));
     check(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 4));
 
     expect(((uint16_t*) raw_res)[0] == ntohs(7));
@@ -1009,12 +1010,12 @@ void test_fc16(nmbs_transport transport) {
         expect(nmbs_write_multiple_registers(&CLIENT, 2, 2, registers) == NMBS_ERROR_NONE);
 
         should("receive no response when sending invalid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2000), htons(0x0200), htons(0)},
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(1), htons(2000), htons(0x0200), htons(0)},
                                 7));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending valid request to broadcast address");
-        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(7), htons(1), htons(0x0200), htons(0)}, 7));
+        check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]) {htons(7), htons(1), htons(0x0200), htons(0)}, 7));
         expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_ERROR_TIMEOUT);
     }
 
@@ -1377,35 +1378,35 @@ void test_fc43_14(nmbs_transport transport) {
     nmbs_set_callbacks_arg(&SERVER, (void*) &callbacks_user_data);
 
     should("return NMBS_EXCEPTION_ILLEGAL_FUNCTION with wrong MEI type");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){69, 1, 0}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {69, 1, 0}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_FUNCTION);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE with wrong Read Device ID code");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 0, 0}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 0, 0}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE with wrong Read Device ID code");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 5, 0}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 5, 0}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with reserved Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 1, 0x07}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 1, 0x07}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with reserved Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 4, 0x07}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 4, 0x07}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with out of range Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 1, 0x03}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 1, 0x03}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with out of range Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 2, 0x01}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 2, 0x01}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS with out of range Object ID");
-    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 3, 0x02}, 3);
+    nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 3, 0x02}, 3);
     expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS);
 
     should("read basic object ids with no error");
@@ -1450,7 +1451,7 @@ void test_fc43_14(nmbs_transport transport) {
                                                         &objects_count) == NMBS_ERROR_TIMEOUT);
 
         should("receive no response when sending invalid request to broadcast address");
-        nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]){mei, 3, 0x02}, 3);
+        nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t[]) {mei, 3, 0x02}, 3);
         expect(nmbs_receive_raw_pdu_response(&CLIENT, NULL, 2) == NMBS_ERROR_TIMEOUT);
     }
 

--- a/tests/nanomodbus_tests.h
+++ b/tests/nanomodbus_tests.h
@@ -8,6 +8,9 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <time.h>
+#ifdef __APPLE__
+typedef suseconds_t __suseconds_t;
+#endif
 #include <unistd.h>
 
 #define expect(expr) assert(expr)


### PR DESCRIPTION
Like in #105, a custom flush function can help reduce the blocking time of the read API, especially when using an intermediate buffer with DMA. I’ll also update my embedded example if this pull request is accepted.

This PR also includes the following minor changes:

- `__suseconds_t` is not available on Apple arm64, so I added an alias for it.
- Added a `launch.json` configuration to debug the tests directly in VS Code using the `cppdbg` debugger.
- Edited `tests/nanomodbus_test.c` to pass clang-format ci step

I've already ran tests and checked all passed.

- unittest & build test : https://github.com/donghoonpark/nanoMODBUS/actions/runs/19188610342
- clang-format : https://github.com/donghoonpark/nanoMODBUS/actions/runs/19188665250