### PR TITLE
fix: Validate registers_bytes before write in recv_read_registers_res

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -589,7 +589,7 @@ static nmbs_error recv_read_registers_res(nmbs_t* nmbs, uint16_t quantity, uint1
     const uint8_t registers_bytes = get_1(nmbs);
     NMBS_DEBUG_PRINT("b %d\t", registers_bytes);
 
-    if (registers_bytes > 250)
+    if (registers_bytes > 250 || registers_bytes != quantity * 2)
         return NMBS_ERROR_INVALID_RESPONSE;
 
     err = recv(nmbs, registers_bytes);
@@ -607,9 +607,6 @@ static nmbs_error recv_read_registers_res(nmbs_t* nmbs, uint16_t quantity, uint1
     err = recv_msg_footer(nmbs);
     if (err != NMBS_ERROR_NONE)
         return err;
-
-    if (registers_bytes != quantity * 2)
-        return NMBS_ERROR_INVALID_RESPONSE;
 
     return NMBS_ERROR_NONE;
 }


### PR DESCRIPTION
The length of registers_bytes needs to be checked before actually writing to the registers to avoid overflow