### PR TITLE
Support for Device / Vendor specific Modbus functions

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -1805,6 +1805,60 @@ static nmbs_error handle_read_device_identification(nmbs_t* nmbs) {
 }
 #endif
 
+#ifdef NMBS_SERVER_CUSTOM_FUNCTION_ENABLED
+static nmbs_error handle_custom_function(nmbs_t* nmbs, 
+                                         nmbs_error (*callback)(uint8_t, uint8_t*, uint16_t*)) {
+
+    uint8_t function_code = nmbs->msg.buf[nmbs->msg.buf_idx - 1];   // Function code is 1 byte ahead of payload
+    uint8_t *payload = &nmbs->msg.buf[nmbs->msg.buf_idx];           // Pointer to start of payload bytes
+    uint16_t *payload_size = nmbs->platform.arg;                    // Pointer to frame size excluding Modbus CRC bytes
+    uint16_t size = (*payload_size - nmbs->msg.buf_idx);            // Skip over header bytes (addr / func)
+
+    // Receive the data bytes from driver into the nanoModbus buffer (excluding CRC)
+    nmbs_error err = recv(nmbs, size);
+    if (err != NMBS_ERROR_NONE)
+        return err;
+
+    // Patch buf_idx to point to Modbus CRC and validate
+    nmbs->msg.buf_idx += size;
+    err = recv_msg_footer(nmbs);
+        if (err != NMBS_ERROR_NONE)
+            return err;
+
+    NMBS_DEBUG_PRINT("Handle custom function: [0x%02X]", function_code);
+
+    if (!nmbs->msg.ignored) {
+
+        /* Call custom function callback with payload and size, the callback is responsible 
+           for modifying the Modbus payload and report the updated size  (excluding CRC bytes). */
+        if (callback) {
+            err = callback(function_code, payload, &size);
+            if (err != NMBS_ERROR_NONE) {
+                if (nmbs_error_is_exception(err))
+                    return send_exception_msg(nmbs, err);
+
+                return send_exception_msg(nmbs, NMBS_EXCEPTION_SERVER_DEVICE_FAILURE);
+            }
+
+            if (!nmbs->msg.broadcast) {
+                put_res_header(nmbs, size);
+                nmbs->msg.buf_idx += size; // Patch size as nanoModbus payload is handled by callback
+                err = send_msg(nmbs);
+                if (err != NMBS_ERROR_NONE)
+                    return err;
+            }
+        }
+        else {
+            return send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_FUNCTION);
+        }
+    }
+    else {
+        return send_exception_msg(nmbs, NMBS_EXCEPTION_SERVER_DEVICE_FAILURE);
+    }
+
+    return NMBS_ERROR_NONE;
+}
+#endif
 
 static nmbs_error handle_req_fc(nmbs_t* nmbs) {
     NMBS_DEBUG_PRINT("fc %d\t", nmbs->msg.fc);
@@ -1883,6 +1937,12 @@ static nmbs_error handle_req_fc(nmbs_t* nmbs) {
             break;
 #endif
         default:
+#ifdef NMBS_SERVER_CUSTOM_FUNCTION_ENABLED
+            if (nmbs->callbacks.custom_function != NULL) {
+                err = handle_custom_function(nmbs, nmbs->callbacks.custom_function);
+                break;
+            }
+#endif
             nmbs->platform.flush(nmbs, nmbs->platform.arg);
             if (!nmbs->msg.ignored)
                 err = send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_FUNCTION);

--- a/nanomodbus.h
+++ b/nanomodbus.h
@@ -236,6 +236,10 @@ typedef struct nmbs_callbacks {
 #endif
 #endif
 
+#ifdef NMBS_SERVER_CUSTOM_FUNCTION_ENABLED
+    nmbs_error (*custom_function)(uint8_t function_code, uint8_t* payload, uint16_t* size);
+#endif
+
     void* arg;               // User data, will be passed to functions above
     uint32_t initialized;    // Reserved, workaround for older user code not calling nmbs_callbacks_create()
 } nmbs_callbacks;


### PR DESCRIPTION
This PR allows support for implementing Device / Vendor specific functions.

Enable this feature by defining `#define NMBS_SERVER_CUSTOM_FUNCTION_ENABLED`.

I have tested this only for the Modbus RTU.

The `handle_req_fc` is modified to any function codes that are not handled by the nanoModbus library through the default case to be handled by `handle_custom_function`. 

The `handle_custom_function` does only validate the CRC of the frame before passing the data and size through the callback function. The user is responsible for modifying the data buffer and patching the size. Then the function appends the CRC and sends back the response.

For this function to work the size of the Modbus frame must be known. I decided to pass this through the `nmbs->platform.arg` pointer like this (I'm not sure if this is the way to do it however this works for me):

```
    // Set platform.arg to RX DMA count so that the Modbus functions know the frame size.
    static uint16_t size;
    size= Uart_BytesToRead(Modbus_Uart_GetInstance());
    if (size> 2)
    {
      size-= 2; // Exclude CRC bytes
      nmbs_set_platform_arg(inNmbs, &size);
      nmbs_server_poll(inNmbs);
    }
```

Then register a handler for the custom function (example custom function below):
`platform_conf.custom_function = CustomFunctionHandler;`

```
nmbs_error CustomFunctionHandler(uint8_t code, uint8_t *data, uint16_t *size)
{
  switch (inFunctionCode)
  {
    case 0x41:
      return GetParam(data, size);
    default:
      return NMBS_EXCEPTION_ILLEGAL_FUNCTION;
  }
}
```

```
static nmbs_error GetParam(uint8_t *data, uint16_t *size)
{
  // Validate frame size
  if (*size != 2)
  {
    return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE;
  }

  uint16_t addr = (data[0] << 8) | data[1];
  uint16_t value;

  // Obtain value of parameter
  if (!Config_GetParam(addr, &value))
  {

    return NMBS_EXCEPTION_SERVER_DEVICE_FAILURE;
  }

  // Encode parameter (shouldn't be necessary  as it is already there)
  data[0] = (uint8_t) (addr >> 8);
  data[1] = (uint8_t) addr;

  // Encode value
  data[2] = (uint8_t) (value >> 8);
  data[3] = (uint8_t) value;

  // Update the size
  *size = 4;

  return NMBS_ERROR_NONE;
}

```