### PR TITLE
Ensures Ilegal data value is exception is returned correctly for FC15

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -1177,9 +1177,6 @@ static nmbs_error handle_write_multiple_coils(nmbs_t* nmbs) {
 
     NMBS_DEBUG_PRINT("a %d\tq %d\tb %d\tcoils ", address, quantity, coils_bytes);
 
-    if (coils_bytes > 246)
-        return NMBS_ERROR_INVALID_REQUEST;
-
     err = recv(nmbs, coils_bytes);
     if (err != NMBS_ERROR_NONE)
         return err;

--- a/tests/nanomodbus_tests.c
+++ b/tests/nanomodbus_tests.c
@@ -822,8 +822,14 @@ void test_fc15(nmbs_transport transport) {
     check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(0), htons(0x0100)}, 6));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
-    should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 2000");
-    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*) (uint16_t[]){htons(1), htons(2000), htons(0x0100)}, 6));
+    should("return NMBS_EXCEPTION_ILLEGAL_DATA_VALUE from server when calling with quantity > 0x07B0");
+
+    const uint16_t max_multiple_coil_pdu_size = 5 + 247;
+    uint16_t pdu_data[3+123] = {0};
+    pdu_data[0] = htons(1);
+    pdu_data[1] = htons(0x07B1);
+    pdu_data[2] = htons(0xF700);
+    check(nmbs_send_raw_pdu(&CLIENT, fc, (uint8_t*)pdu_data, max_multiple_coil_pdu_size));
     expect(nmbs_receive_raw_pdu_response(&CLIENT, raw_res, 2) == NMBS_EXCEPTION_ILLEGAL_DATA_VALUE);
 
     should("return NMBS_EXCEPTION_ILLEGAL_DATA_ADDRESS from server when calling with address + quantity > 0xFFFF + 1");


### PR DESCRIPTION
Exeception code 3 (illegal data value) is now returned correctly for coil quantities greater than 1968 with Function Code 15. This is inline with the flowchart given in the modbus standard.

The exception wasn't being returned as the number of coils was checked prematurely. 

I think the previous test didn't catch it as the number of bytes field was set to equal one rather than 1968/8 = 246. In the new test the number of bytes field reflects the number of outputs given in the request.

