### PR TITLE
Fix off-by-one in TCP MBAP length validation (1-byte OOB write)

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -368,7 +368,7 @@ static nmbs_error recv_msg_header(nmbs_t* nmbs, bool* first_byte_received) {
         nmbs->msg.unit_id = get_1(nmbs);
         nmbs->msg.fc = get_1(nmbs);
 
-        if (length < 2 || length > 255)
+        if (length < 2 || length > 254)
             return NMBS_ERROR_INVALID_TCP_MBAP;
 
         // Receive the rest of the message


### PR DESCRIPTION
## Bug

In `recv_msg_header()` (TCP branch), the MBAP `length` field is validated with:

```c
if (length < 2 || length > 255)
    return NMBS_ERROR_INVALID_TCP_MBAP;

// Receive the rest of the message
err = recv(nmbs, length - 2);
```

At this point the 8-byte MBAP header has already been parsed, so `msg.buf_idx == 8`. `recv(nmbs, length - 2)` writes starting at `buf_idx`, i.e. into `msg.buf[buf_idx .. buf_idx + (length - 2) - 1]`.

`msg.buf` is declared as `uint8_t buf[260]` (`nanomodbus.h`), so valid indices are `0..259`. With the maximum currently-accepted `length == 255`, the write is `recv(nmbs, 253)`, covering `buf[8..260]` — index `260` is one byte past the end of the array. That extra byte lands on the low byte of `msg.buf_idx` itself, the very next struct member after `buf`, corrupting internal parser state from a single attacker-controlled length byte on the wire.

I reproduced this with a mock `platform.read` sending a crafted MBAP header (`length = 0x00FF = 255`) followed by 253 payload bytes: `msg.buf_idx` gets clobbered from `8` to the low byte of the last payload byte written.

## Fix

Tighten the upper bound from `255` to `254`. With `length == 254`, `recv(nmbs, 252)` writes exactly `buf[8..259]`, filling `buf[260]` with zero slack and no overflow. Verified this boundary case is still accepted and produces no out-of-bounds write, and that ordinary small requests are unaffected.

I also ran the project's own test suite (`tests/nanomodbus_tests.c`) before and after the change with identical pass results.

This is the same one-line class of issue as the existing off-by-one/overflow checks in this file; no other behavior is changed.
