### PR TITLE
Add explicit casts at narrowing integer conversions

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -68,8 +68,8 @@ static void discard_n(nmbs_t* nmbs, uint16_t n) {
 
 
 static uint16_t get_2(nmbs_t* nmbs) {
-    const uint16_t result =
-            ((uint16_t) nmbs->msg.buf[nmbs->msg.buf_idx]) << 8 | (uint16_t) nmbs->msg.buf[nmbs->msg.buf_idx + 1];
+    const uint16_t result = (uint16_t) (((uint16_t) nmbs->msg.buf[nmbs->msg.buf_idx]) << 8 |
+                                        (uint16_t) nmbs->msg.buf[nmbs->msg.buf_idx + 1]);
     nmbs->msg.buf_idx += 2;
     return result;
 }
@@ -118,7 +118,7 @@ static uint16_t* get_regs(nmbs_t* nmbs, uint16_t n) {
     uint16_t* msg_buf_ptr = (uint16_t*) (nmbs->msg.buf + nmbs->msg.buf_idx);
     nmbs->msg.buf_idx += n * 2;
     while (n--) {
-        msg_buf_ptr[n] = (msg_buf_ptr[n] << 8) | ((msg_buf_ptr[n] >> 8) & 0xFF);
+        msg_buf_ptr[n] = (uint16_t) ((msg_buf_ptr[n] << 8) | ((msg_buf_ptr[n] >> 8) & 0xFF));
     }
     return msg_buf_ptr;
 }
@@ -131,7 +131,7 @@ static void put_regs(nmbs_t* nmbs, const uint16_t* data, uint16_t n) {
     uint16_t* msg_buf_ptr = (uint16_t*) (nmbs->msg.buf + nmbs->msg.buf_idx);
     nmbs->msg.buf_idx += n * 2;
     while (n--) {
-        msg_buf_ptr[n] = (data[n] << 8) | ((data[n] >> 8) & 0xFF);
+        msg_buf_ptr[n] = (uint16_t) ((data[n] << 8) | ((data[n] >> 8) & 0xFF));
     }
 }
 #endif
@@ -139,7 +139,7 @@ static void put_regs(nmbs_t* nmbs, const uint16_t* data, uint16_t n) {
 
 static void swap_regs(uint16_t* data, uint16_t n) {
     while (n--) {
-        data[n] = (data[n] << 8) | ((data[n] >> 8) & 0xFF);
+        data[n] = (uint16_t) ((data[n] << 8) | ((data[n] >> 8) & 0xFF));
     }
 }
 
@@ -2077,7 +2077,7 @@ nmbs_error nmbs_write_multiple_coils(nmbs_t* nmbs, uint16_t address, uint16_t qu
     if ((uint32_t) address + (uint32_t) quantity > ((uint32_t) 0xFFFF) + 1)
         return NMBS_ERROR_INVALID_ARGUMENT;
 
-    uint8_t coils_bytes = (quantity + 7) / 8;
+    uint8_t coils_bytes = (uint8_t) ((quantity + 7) / 8);
 
     msg_state_req(nmbs, 15);
     put_req_header(nmbs, 5 + coils_bytes);
@@ -2111,7 +2111,7 @@ nmbs_error nmbs_write_multiple_registers(nmbs_t* nmbs, uint16_t address, uint16_
     if ((uint32_t) address + (uint32_t) quantity > ((uint32_t) 0xFFFF) + 1)
         return NMBS_ERROR_INVALID_ARGUMENT;
 
-    const uint8_t registers_bytes = quantity * 2;
+    const uint8_t registers_bytes = (uint8_t) (quantity * 2);
 
     msg_state_req(nmbs, 16);
     put_req_header(nmbs, 5 + registers_bytes);
@@ -2184,7 +2184,7 @@ nmbs_error nmbs_write_file_record(nmbs_t* nmbs, uint16_t file_number, uint16_t r
     msg_state_req(nmbs, 21);
     put_req_header(nmbs, 8 + data_size);
 
-    put_1(nmbs, 7 + data_size);    // add Byte Count
+    put_1(nmbs, (uint8_t) (7 + data_size));    // add Byte Count
     put_1(nmbs, 6);                // add Reference Type const
     put_2(nmbs, file_number);
     put_2(nmbs, record_number);
@@ -2218,7 +2218,7 @@ nmbs_error nmbs_read_write_registers(nmbs_t* nmbs, uint16_t read_address, uint16
     if ((uint32_t) write_address + (uint32_t) write_quantity > ((uint32_t) 0xFFFF) + 1)
         return NMBS_ERROR_INVALID_ARGUMENT;
 
-    const uint8_t registers_bytes = write_quantity * 2;
+    const uint8_t registers_bytes = (uint8_t) (write_quantity * 2);
 
     msg_state_req(nmbs, 23);
     put_req_header(nmbs, 9 + registers_bytes);


### PR DESCRIPTION
In C, the operands of `<<`, `|`, `*`, `+` and `/` are promoted to `int`, so every one of these expressions has type `int` even when both operands are `uint8_t`/`uint16_t`. Assigning the result back to a narrow type is an implicit narrowing conversion, which compilers report under `-Wconversion` (GCC/Clang), `/W4` (MSVC, C4244).

Every affected value is provably in range, so these casts document the intent rather than change behaviour:

* `get_2()`, `get_regs()`, `put_regs()`, `swap_regs()` - byte swaps of a `uint16_t`; the result cannot exceed `0xFFFF`.
* `nmbs_write_multiple_coils()` - `quantity <= 0x07B0`, so `(quantity + 7) / 8 <= 246`.
* `nmbs_write_multiple_registers()` - `quantity <= 0x007B`, so `quantity * 2 <= 246`.
* `nmbs_write_file_record()` - `count <= 122`, so `7 + count * 2 <= 251`.
* `nmbs_read_write_registers()` - `write_quantity <= 0x0079`, so `write_quantity * 2 <= 242`.

Each bound is already enforced by the argument validation at the top of the corresponding function.