### PR TITLE
Fix unaligned 16-bit access in swap_regs()

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -138,8 +138,12 @@ static void put_regs(nmbs_t* nmbs, const uint16_t* data, uint16_t n) {
 
 
 static void swap_regs(uint16_t* data, uint16_t n) {
-    while (n--) {
-        data[n] = (data[n] << 8) | ((data[n] >> 8) & 0xFF);
+    // Swap bytes in place to avoid unaligned 16-bit access, which hardfaults on e.g. Cortex-M0/M0+
+    uint8_t* bytes = (uint8_t*) data;
+    for (uint16_t i = 0; i < n; i++) {
+        uint8_t tmp = bytes[2 * i];
+        bytes[2 * i] = bytes[2 * i + 1];
+        bytes[2 * i + 1] = tmp;
     }
 }
 


### PR DESCRIPTION
swap_regs() byte-swapped each register through 16-bit indexed writes (data[n]) on buffers that point directly into the message buffer, which is not guaranteed to be 2-byte aligned. On cores that require aligned memory accesses this triggers a HardFault. The issue is not observable on cores that support unaligned memory accesses, but was reproducable on Cortex-M0/M0+.

Perform the byte swap in place through a uint8_t pointer so that only byte-wide accesses are used, making the function alignment-agnostic.